### PR TITLE
Feature remove arel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 language: ruby
 rvm:
-  - 2.3.1
-  - 2.2.5
+  - 2.4.0
+  - 2.3.3
+  - 2.2.6
   - 2.1.10
-  - 2.0.0
 env:
+  - "RAILS_VERSION=5.0.0"
   - "RAILS_VERSION=4.2.0"
   - "RAILS_VERSION=4.1.0"
   - "RAILS_VERSION=4.0.0"

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,6 @@ source 'https://rubygems.org'
 gemspec
 
 rails_version = ENV['RAILS_VERSION'] || 'default'
-
 rails = case rails_version
           when 'master'
             { :github => 'rails/rails' }
@@ -17,5 +16,5 @@ rails = case rails_version
 
 gem 'rails', rails
 group :development do
-  gem 'combustion', github: 'patorash/combustion', branch: 'master'
+  gem 'combustion', '~> 0.5'
 end

--- a/lib/acts_as_footprintable/footprint.rb
+++ b/lib/acts_as_footprintable/footprint.rb
@@ -10,8 +10,8 @@ module ActsAsFootprintable
     belongs_to :footprintable, :polymorphic => true
     belongs_to :footprinter, :polymorphic => true
 
-    scope :for_type, lambda{|klass| where(:footprintable_type => klass)}
-    scope :by_type,  lambda{|klass| where(:footprinter_type   => klass)}
+    scope :for_type, lambda{|klass| where(:footprintable_type => klass.name)}
+    scope :by_type,  lambda{|klass| where(:footprinter_type   => klass.name)}
 
     validates :footprintable_id, :presence => true
     validates :footprinter_id, :presence => true

--- a/lib/acts_as_footprintable/version.rb
+++ b/lib/acts_as_footprintable/version.rb
@@ -1,4 +1,4 @@
 # coding: utf-8
 module ActsAsFootprintable
-  VERSION = "0.2.3"
+  VERSION = "0.3.0"
 end


### PR DESCRIPTION
Arelを使っていた影響で、prepared statementsをfalseにした場合に動かない不具合が発生した。
また、Arelは非公開APIなので(ActiveRecord 5.1以上になると公開されるという情報はある)、
現状はgemで利用しないほうがいいと考えて、それを除くように修正した。