### PR TITLE
Fix travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ rvm:
   - 2.1.10
 env:
   - "RAILS_VERSION=5.0.0"
+  - "RAILS_VERSION=4.2.8"
   - "RAILS_VERSION=4.2.0"
   - "RAILS_VERSION=4.1.0"
   - "RAILS_VERSION=4.0.0"
@@ -19,3 +20,11 @@ matrix:
   exclude:
     - rvm: 2.1.10
       env: "RAILS_VERSION=5.0.0"
+    - rvm: 2.4.0
+      env: "RAILS_VERSION=4.2.0"
+    - rvm: 2.4.0
+      env: "RAILS_VERSION=4.1.0"
+    - rvm: 2.4.0
+      env: "RAILS_VERSION=4.0.0"
+    - rvm: 2.4.0
+      env: "RAILS_VERSION=3.2.0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,8 @@ branches:
   only:
     - master
     - travis
+
+matrix:
+  exclude:
+    - rvm: 2.1.10
+      env: "RAILS_VERSION=5.0.0"

--- a/Gemfile
+++ b/Gemfile
@@ -16,5 +16,16 @@ rails = case rails_version
 
 gem 'rails', rails
 group :development do
-  gem 'combustion', '~> 0.5'
+  if rails_version == 'default' ||
+      (Gem::Version.correct?(rails_version) && Gem::Version.new(rails_version) < Gem::Version.new("4.0.0"))
+    # rails < 4 needs combustion v0.5.2 (does not work with v0.5.3)
+    # An error occurred while loading ./spec/footprinter_spec.rb.
+    # Failure/Error: Combustion.initialize! :active_record
+    #
+    # PG::ConnectionBad:
+    #   FATAL:  database "acts_as_footprintable" does not exist
+    gem 'combustion', "0.5.2"
+  else
+    gem 'combustion'
+  end
 end


### PR DESCRIPTION
* rails < 4 needs combustion v0.5.2 (does not work with v0.5.3+)
  * But combustion's Appraisals still support rails-3.2, there should be some way to solve it
* Rails 5.x only support ruby 2.2.2+ so exclude CI with ruby 2.1.10
* Rails 4.2.8 is the first release with ruby 2.4 support